### PR TITLE
Solucion a bug encontrado

### DIFF
--- a/fases/fase2/parser/visitor/Tokenizador.js
+++ b/fases/fase2/parser/visitor/Tokenizador.js
@@ -224,9 +224,20 @@ end module parser
             cambioLength = node.val.length;
         }
 
-        const condition = node.isCase 
-        ? `tolower(${cambioNodeVal}) == tolower(input(cursor:cursor + ${ cambioLength - 1} ))`
-        :  `${cambioNodeVal} == input(cursor:cursor + ${cambioLength - 1} )`;
+        let condition = ""
+
+        if(node.isCase){
+            condition = `tolower(${cambioNodeVal}) == tolower(input(cursor:cursor + ${ cambioLength - 1} ))`
+        }else{
+
+            if(cambioNodeVal == "char(10)"){
+                condition = `char(13) == input(cursor:cursor + ${cambioLength - 1} ) .or. ${cambioNodeVal} == input(cursor:cursor + ${cambioLength - 1} )`
+            }else{
+
+                condition = `${cambioNodeVal} == input(cursor:cursor + ${cambioLength - 1} )`
+            }
+
+        }
         return this.renderQuantifierOption(node.qty, condition, cambioLength)
     }
 


### PR DESCRIPTION
Al hacer pruebas nos dimos cuenta que esta gramatica
```
a = "hola" b
b = "\n"
```

al ejecutar una entrada de 
```
hola


```

Nos reconocia dos errores lexicos, asi que investigamos y fortran al reconocer un salto de linea reconoce tambien un retorno de carro.

![image](https://github.com/user-attachments/assets/705abf01-576f-4e04-a88b-de1e7cd04478)


Para evitar esos errores lexicos agregamos la validacion del retorno de carro cuando se encuentra un salto de linea.

![image](https://github.com/user-attachments/assets/d251c517-d8f6-4ad1-8537-f1337f189dc7)


Todo el grupo 10 trabajo para solucionar este "bug".
